### PR TITLE
Fixed a deprecated export condition 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,10 @@
 {
   "name": "saos",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Svelte Animation on Scroll",
   "main": "index.js",
   "module": "index.mjs",
-  "svelte": "Saos.svelte",
-  "scripts": {
-    "package": "svelte-kit package"
-  },
+  "svelte": "index.js",
   "keywords": [
     "svelte",
     "css",
@@ -27,5 +24,10 @@
   "bugs": {
     "url": "https://github.com/shiryel/saos/issues"
   },
-  "type": "module"
+  "type": "module",
+  "exports": {
+    ".": {
+      "svelte": "./index.js"
+    }
+  }
 }


### PR DESCRIPTION
The module was not working and I got this warning

"[vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.

saos@1.3.1

Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition for details."

I went ahead and fixed it. I hope at least, I am no experienced programmer but I just followed what was explained in the link and it fixed it. Thanks for making this library!